### PR TITLE
feat(api): add mock API for auth and admin settings

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,1 +1,58 @@
-export default {}
+// Mock API to develop frontend first.
+// Later: replace functions to call your Laravel endpoints via axios.
+
+const MOCK_ADMIN = {
+  id: 1,
+  name: 'System Admin',
+  email: 'admin@aequitas.com',
+  role: 'admin',
+};
+
+const MOCK_USER = {
+  id: 2,
+  name: 'Aequitas User',
+  email: 'user@aequitas.com',
+  role: 'user',
+};
+
+// In-memory settings store
+let SETTINGS = {
+  'whatsapp.token': '••••••••',
+  'whatsapp.phone_number_id': '210058865514527',
+  'whatsapp.template_name': 'realestatedemo',
+  'whatsapp.lang_code': 'en',
+  'whatsapp.image_url': 'https://example.com/image.jpg',
+};
+
+export function mockLogin({ email, password }) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      if (email === 'admin@aequitas.com' && password === 'Secret123!') {
+        resolve({ token: 'mock_admin_token', user: MOCK_ADMIN });
+      } else if (email === 'user@aequitas.com' && password === 'Secret123!') {
+        resolve({ token: 'mock_user_token', user: MOCK_USER });
+      } else {
+        reject(new Error('Invalid credentials'));
+      }
+    }, 400);
+  });
+}
+
+export function mockLogout() {
+  return Promise.resolve({ ok: true });
+}
+
+export function mockMe(token) {
+  if (token === 'mock_admin_token') return Promise.resolve(MOCK_ADMIN);
+  if (token === 'mock_user_token') return Promise.resolve(MOCK_USER);
+  return Promise.reject(new Error('Unauthenticated'));
+}
+
+export function mockGetAdminSettings() {
+  return new Promise((resolve) => setTimeout(() => resolve({ ...SETTINGS }), 250));
+}
+
+export function mockUpdateAdminSettings(payload) {
+  SETTINGS = { ...SETTINGS, ...payload };
+  return new Promise((resolve) => setTimeout(() => resolve({ message: 'Settings updated' }), 250));
+}


### PR DESCRIPTION
## Summary
- implement a mock API layer in `src/lib/api.js` for authentication and admin settings using an in-memory store

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba8615b76083298c67163c02b13a25