### PR TITLE
feat: implement core auth pages

### DIFF
--- a/src/pages/AdminSettings.jsx
+++ b/src/pages/AdminSettings.jsx
@@ -1,3 +1,47 @@
+import { useEffect, useState } from 'react';
+import { mockGetAdminSettings, mockUpdateAdminSettings } from '../lib/api';
+
 export default function AdminSettings() {
-  return null
+  const [form, setForm] = useState({
+    'whatsapp.token': '',
+    'whatsapp.phone_number_id': '',
+    'whatsapp.template_name': '',
+    'whatsapp.lang_code': '',
+    'whatsapp.image_url': '',
+  });
+  const [msg, setMsg] = useState('');
+
+  useEffect(() => {
+    mockGetAdminSettings().then((data) => setForm(prev => ({ ...prev, ...data })));
+  }, []);
+
+  const save = async (e) => {
+    e.preventDefault();
+    setMsg('');
+    await mockUpdateAdminSettings(form);
+    setMsg('Settings saved');
+    setTimeout(() => setMsg(''), 1500);
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold">Admin Settings</h1>
+      {msg && <div className="text-green-600">{msg}</div>}
+      <form onSubmit={save} className="grid md:grid-cols-2 gap-4">
+        {Object.entries(form).map(([key, val]) => (
+          <label key={key} className="block">
+            <span className="block text-sm mb-1">{key}</span>
+            <input
+              className="w-full border rounded px-3 py-2"
+              value={val ?? ''}
+              onChange={e => setForm({ ...form, [key]: e.target.value })}
+            />
+          </label>
+        ))}
+        <div className="md:col-span-2">
+          <button className="px-4 py-2 rounded-xl bg-black text-white">Save</button>
+        </div>
+      </form>
+    </div>
+  );
 }

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,3 +1,16 @@
 export default function Dashboard() {
-  return null
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold">Dashboard</h1>
+      <div className="grid md:grid-cols-3 gap-4">
+        <div className="p-4 bg-white rounded-2xl border">Total Campaigns: —</div>
+        <div className="p-4 bg-white rounded-2xl border">Templates: —</div>
+        <div className="p-4 bg-white rounded-2xl border">Delivery Rate: —</div>
+      </div>
+      <div className="p-4 bg-white rounded-2xl border">
+        <b>Recent Campaigns</b>
+        <div className="text-sm text-slate-500 mt-2">Coming soon…</div>
+      </div>
+    </div>
+  );
 }

--- a/src/pages/Forbidden.jsx
+++ b/src/pages/Forbidden.jsx
@@ -1,3 +1,8 @@
 export default function Forbidden() {
-  return null
+  return (
+    <div className="p-6 bg-white rounded-2xl border">
+      <h1 className="text-xl font-semibold mb-2">403 — Forbidden</h1>
+      <p className="text-slate-600 text-sm">You don’t have permission to access this page.</p>
+    </div>
+  );
 }

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,3 +1,56 @@
+import { useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+import { useNavigate } from 'react-router-dom';
+
 export default function Login() {
-  return null
+  const nav = useNavigate();
+  const { login } = useAuth();
+  const [form, setForm] = useState({ email: '', password: '' });
+  const [err, setErr] = useState('');
+
+  const submit = async (e) => {
+    e.preventDefault();
+    setErr('');
+    try {
+      await login(form.email, form.password);
+      nav('/dashboard');
+    } catch {
+      setErr('Invalid email or password.');
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-600 to-indigo-700 p-4">
+      <form onSubmit={submit} className="w-full max-w-sm bg-white p-6 rounded-2xl shadow-xl">
+        <h1 className="text-xl font-semibold mb-1 text-center">Aequitas Reach</h1>
+        <p className="text-xs text-center text-slate-500 mb-5">Sign in to continue</p>
+        {err && <div className="mb-3 text-red-600 text-sm">{err}</div>}
+
+        <label className="block mb-1 text-sm">Email</label>
+        <input
+          className="w-full border rounded px-3 py-2 mb-3"
+          type="email"
+          value={form.email}
+          onChange={e => setForm({ ...form, email: e.target.value })}
+          placeholder="admin@aequitas.com or user@aequitas.com"
+        />
+
+        <label className="block mb-1 text-sm">Password</label>
+        <input
+          className="w-full border rounded px-3 py-2 mb-5"
+          type="password"
+          value={form.password}
+          onChange={e => setForm({ ...form, password: e.target.value })}
+          placeholder="Secret123!"
+        />
+
+        <button className="w-full rounded-xl py-2 bg-black text-white">Login</button>
+
+        <div className="mt-4 text-xs text-slate-500">
+          <p><b>Demo creds:</b> admin@aequitas.com / Secret123! (Admin)</p>
+          <p>user@aequitas.com / Secret123! (User)</p>
+        </div>
+      </form>
+    </div>
+  );
 }

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,3 +1,15 @@
+import { useAuth } from '../context/AuthContext';
+
 export default function Profile() {
-  return null
+  const { user } = useAuth();
+  return (
+    <div className="p-4 bg-white rounded-2xl border">
+      <h2 className="text-xl font-semibold">My Profile</h2>
+      <div className="mt-3 text-sm text-slate-700">
+        <div><b>Name:</b> {user?.name}</div>
+        <div><b>Email:</b> {user?.email}</div>
+        <div><b>Role:</b> {user?.role}</div>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add login page with form handling and demo credentials
- introduce basic dashboard and admin settings placeholders
- add forbidden and profile pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba8c511490832999b2772a4d5c564d