### PR TITLE
feat(app): replace Vite default with router + auth pages

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -1,2 +1,7 @@
 - After pulling, run: npm i -D tailwindcss postcss autoprefixer
 - If Tailwind added now, restart dev server.
+After pulling:
+1) npm i
+2) npm i react-router-dom
+3) npm run dev
+Then open http://localhost:5173/login

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,57 +2,26 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import AuthProvider from './context/AuthContext';
 import ProtectedRoute from './components/ProtectedRoute';
 import Layout from './components/Layout';
-
 import Login from './pages/Login';
 import Dashboard from './pages/Dashboard';
-import AdminSettings from './pages/AdminSettings';
+import AdminSettings from './pages/AdminSettings'; // optional later
 import Forbidden from './pages/Forbidden';
 import Profile from './pages/Profile';
 
-export default function App() {
+export default function App(){
   return (
     <AuthProvider>
       <BrowserRouter>
         <Routes>
-          <Route path="/login" element={<Login />} />
-          <Route path="/403" element={<Forbidden />} />
-
-          <Route path="/" element={
-            <ProtectedRoute>
-              <Layout>
-                <Dashboard />
-              </Layout>
-            </ProtectedRoute>
-          } />
-
-          <Route path="/dashboard" element={
-            <ProtectedRoute>
-              <Layout>
-                <Dashboard />
-              </Layout>
-            </ProtectedRoute>
-          } />
-
-          <Route path="/profile" element={
-            <ProtectedRoute>
-              <Layout>
-                <Profile />
-              </Layout>
-            </ProtectedRoute>
-          } />
-
-          <Route path="/admin/settings" element={
-            <ProtectedRoute role="admin">
-              <Layout>
-                <AdminSettings />
-              </Layout>
-            </ProtectedRoute>
-          } />
-
+          <Route path="/login" element={<Login/>} />
+          <Route path="/403" element={<Forbidden/>} />
+          <Route path="/dashboard" element={<ProtectedRoute><Layout><Dashboard/></Layout></ProtectedRoute>} />
+          <Route path="/profile" element={<ProtectedRoute><Layout><Profile/></Layout></ProtectedRoute>} />
+          <Route path="/admin/settings" element={<ProtectedRoute role="admin"><Layout><AdminSettings/></Layout></ProtectedRoute>} />
+          <Route path="/" element={<Navigate to="/dashboard" replace />} />
           <Route path="*" element={<Navigate to="/dashboard" replace />} />
         </Routes>
       </BrowserRouter>
     </AuthProvider>
   );
 }
-

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -3,7 +3,6 @@ import { useAuth } from '../context/AuthContext';
 
 export default function Layout({ children }) {
   const { user, logout } = useAuth();
-
   return (
     <div className="min-h-screen bg-slate-50">
       <header className="bg-white border-b">
@@ -15,7 +14,6 @@ export default function Layout({ children }) {
           </div>
         </div>
       </header>
-
       <div className="max-w-6xl mx-auto px-4 py-6 grid grid-cols-12 gap-6">
         <aside className="col-span-12 md:col-span-3 lg:col-span-2">
           <nav className="bg-white rounded-2xl border p-3 space-y-2">
@@ -26,10 +24,7 @@ export default function Layout({ children }) {
             )}
           </nav>
         </aside>
-
-        <main className="col-span-12 md:col-span-9 lg:col-span-10">
-          {children}
-        </main>
+        <main className="col-span-12 md:col-span-9 lg:col-span-10">{children}</main>
       </div>
     </div>
   );

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -3,7 +3,7 @@ import { useAuth } from '../context/AuthContext';
 
 export default function ProtectedRoute({ children, role }) {
   const { user, bootstrapped } = useAuth();
-  if (!bootstrapped) return null; // could be a loader
+  if (!bootstrapped) return null;
   if (!user) return <Navigate to="/login" replace />;
   if (role && user.role !== role) return <Navigate to="/403" replace />;
   return children;

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,8 +1,26 @@
 import { createContext, useContext, useEffect, useState } from 'react';
-import { mockLogin, mockLogout, mockMe } from '../lib/api';
 
 const AuthCtx = createContext(null);
 export const useAuth = () => useContext(AuthCtx);
+
+const MOCK_ADMIN = { id:1, name:'System Admin', email:'admin@aequitas.com', role:'admin' };
+const MOCK_USER  = { id:2, name:'Aequitas User', email:'user@aequitas.com', role:'user' };
+
+function mockMe(token){
+  if (token==='mock_admin_token') return Promise.resolve(MOCK_ADMIN);
+  if (token==='mock_user_token')  return Promise.resolve(MOCK_USER);
+  return Promise.reject(new Error('Unauthenticated'));
+}
+function mockLogin({email,password}){
+  return new Promise((resolve,reject)=>{
+    setTimeout(()=>{
+      if (email==='admin@aequitas.com' && password==='Secret123!') resolve({token:'mock_admin_token', user:MOCK_ADMIN});
+      else if (email==='user@aequitas.com' && password==='Secret123!') resolve({token:'mock_user_token', user:MOCK_USER});
+      else reject(new Error('Invalid'));
+    },300);
+  });
+}
+function mockLogout(){ return Promise.resolve({ok:true}); }
 
 export default function AuthProvider({ children }) {
   const [user, setUser] = useState(null);
@@ -11,25 +29,20 @@ export default function AuthProvider({ children }) {
   useEffect(() => {
     const token = localStorage.getItem('ar_token');
     if (!token) { setBootstrapped(true); return; }
-    mockMe(token).then(setUser).finally(() => setBootstrapped(true));
+    mockMe(token).then(setUser).finally(()=>setBootstrapped(true));
   }, []);
 
-  const login = async (email, password) => {
-    const { token, user } = await mockLogin({ email, password });
+  const login = async (email,password)=>{
+    const {token, user} = await mockLogin({email,password});
     localStorage.setItem('ar_token', token);
     setUser(user);
     return user;
   };
-
-  const logout = async () => {
+  const logout = async ()=>{
     await mockLogout();
     localStorage.removeItem('ar_token');
     setUser(null);
   };
 
-  return (
-    <AuthCtx.Provider value={{ user, login, logout, bootstrapped }}>
-      {children}
-    </AuthCtx.Provider>
-  );
+  return <AuthCtx.Provider value={{ user, login, logout, bootstrapped }}>{children}</AuthCtx.Provider>;
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -8,4 +8,3 @@ ReactDOM.createRoot(document.getElementById('root')).render(
     <App />
   </React.StrictMode>,
 )
-

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,4 +1,4 @@
-export default function Dashboard() {
+export default function Dashboard(){
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-semibold">Dashboard</h1>
@@ -7,10 +7,7 @@ export default function Dashboard() {
         <div className="p-4 bg-white rounded-2xl border">Templates: —</div>
         <div className="p-4 bg-white rounded-2xl border">Delivery Rate: —</div>
       </div>
-      <div className="p-4 bg-white rounded-2xl border">
-        <b>Recent Campaigns</b>
-        <div className="text-sm text-slate-500 mt-2">Coming soon…</div>
-      </div>
+      <div className="p-4 bg-white rounded-2xl border"><b>Recent Campaigns</b><div className="text-sm text-slate-500 mt-2">Coming soon…</div></div>
     </div>
   );
 }

--- a/src/pages/Forbidden.jsx
+++ b/src/pages/Forbidden.jsx
@@ -1,4 +1,4 @@
-export default function Forbidden() {
+export default function Forbidden(){
   return (
     <div className="p-6 bg-white rounded-2xl border">
       <h1 className="text-xl font-semibold mb-2">403 — Forbidden</h1>

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -5,18 +5,14 @@ import { useNavigate } from 'react-router-dom';
 export default function Login() {
   const nav = useNavigate();
   const { login } = useAuth();
-  const [form, setForm] = useState({ email: '', password: '' });
+  const [form, setForm] = useState({ email:'', password:'' });
   const [err, setErr] = useState('');
 
-  const submit = async (e) => {
+  const submit = async (e)=>{
     e.preventDefault();
     setErr('');
-    try {
-      await login(form.email, form.password);
-      nav('/dashboard');
-    } catch {
-      setErr('Invalid email or password.');
-    }
+    try { await login(form.email, form.password); nav('/dashboard'); }
+    catch { setErr('Invalid email or password.'); }
   };
 
   return (
@@ -25,27 +21,13 @@ export default function Login() {
         <h1 className="text-xl font-semibold mb-1 text-center">Aequitas Reach</h1>
         <p className="text-xs text-center text-slate-500 mb-5">Sign in to continue</p>
         {err && <div className="mb-3 text-red-600 text-sm">{err}</div>}
-
         <label className="block mb-1 text-sm">Email</label>
-        <input
-          className="w-full border rounded px-3 py-2 mb-3"
-          type="email"
-          value={form.email}
-          onChange={e => setForm({ ...form, email: e.target.value })}
-          placeholder="admin@aequitas.com or user@aequitas.com"
-        />
-
+        <input className="w-full border rounded px-3 py-2 mb-3" type="email" value={form.email}
+               onChange={e=>setForm({...form, email:e.target.value})} placeholder="admin@aequitas.com or user@aequitas.com"/>
         <label className="block mb-1 text-sm">Password</label>
-        <input
-          className="w-full border rounded px-3 py-2 mb-5"
-          type="password"
-          value={form.password}
-          onChange={e => setForm({ ...form, password: e.target.value })}
-          placeholder="Secret123!"
-        />
-
+        <input className="w-full border rounded px-3 py-2 mb-5" type="password" value={form.password}
+               onChange={e=>setForm({...form, password:e.target.value})} placeholder="Secret123!"/>
         <button className="w-full rounded-xl py-2 bg-black text-white">Login</button>
-
         <div className="mt-4 text-xs text-slate-500">
           <p><b>Demo creds:</b> admin@aequitas.com / Secret123! (Admin)</p>
           <p>user@aequitas.com / Secret123! (User)</p>

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,6 +1,5 @@
 import { useAuth } from '../context/AuthContext';
-
-export default function Profile() {
+export default function Profile(){
   const { user } = useAuth();
   return (
     <div className="p-4 bg-white rounded-2xl border">


### PR DESCRIPTION
## Summary
- install note for react-router-dom and run instructions in DEV_NOTES
- add AuthContext with mock login and ProtectedRoute for role-based routing
- implement auth-first pages and layout, wiring routes in App

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba9a2ce7008329a19a042443c75cf6