### PR TITLE
feat(ui): Tailwind dark login screen + html/body full-height classes

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -5,3 +5,9 @@ After pulling:
 2) npm i react-router-dom
 3) npm run dev
 Then open http://localhost:5173/login
+Tailwind notes:
+- Ensure Tailwind is installed and configured:
+  npm i -D tailwindcss postcss autoprefixer
+  npx tailwindcss init -p
+- Restart dev server if styles don’t apply: npm run dev
+Open http://localhost:5173/login to see the dark Tailwind login screen.

--- a/index.html
+++ b/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="h-full bg-gray-900">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
   </head>
-  <body>
+  <body class="h-full">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -5,34 +5,98 @@ import { useNavigate } from 'react-router-dom';
 export default function Login() {
   const nav = useNavigate();
   const { login } = useAuth();
-  const [form, setForm] = useState({ email:'', password:'' });
+  const [form, setForm] = useState({ email: '', password: '' });
   const [err, setErr] = useState('');
 
-  const submit = async (e)=>{
+  const submit = async (e) => {
     e.preventDefault();
     setErr('');
-    try { await login(form.email, form.password); nav('/dashboard'); }
-    catch { setErr('Invalid email or password.'); }
+    try {
+      await login(form.email, form.password);
+      nav('/dashboard');
+    } catch {
+      setErr('Invalid email or password.');
+    }
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-600 to-indigo-700 p-4">
-      <form onSubmit={submit} className="w-full max-w-sm bg-white p-6 rounded-2xl shadow-xl">
-        <h1 className="text-xl font-semibold mb-1 text-center">Aequitas Reach</h1>
-        <p className="text-xs text-center text-slate-500 mb-5">Sign in to continue</p>
-        {err && <div className="mb-3 text-red-600 text-sm">{err}</div>}
-        <label className="block mb-1 text-sm">Email</label>
-        <input className="w-full border rounded px-3 py-2 mb-3" type="email" value={form.email}
-               onChange={e=>setForm({...form, email:e.target.value})} placeholder="admin@aequitas.com or user@aequitas.com"/>
-        <label className="block mb-1 text-sm">Password</label>
-        <input className="w-full border rounded px-3 py-2 mb-5" type="password" value={form.password}
-               onChange={e=>setForm({...form, password:e.target.value})} placeholder="Secret123!"/>
-        <button className="w-full rounded-xl py-2 bg-black text-white">Login</button>
-        <div className="mt-4 text-xs text-slate-500">
-          <p><b>Demo creds:</b> admin@aequitas.com / Secret123! (Admin)</p>
-          <p>user@aequitas.com / Secret123! (User)</p>
-        </div>
-      </form>
+    <div className="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
+      <div className="sm:mx-auto sm:w-full sm:max-w-sm">
+        <img
+          src="https://tailwindcss.com/plus-assets/img/logos/mark.svg?color=indigo&shade=500"
+          alt="Aequitas"
+          className="mx-auto h-10 w-auto"
+        />
+        <h2 className="mt-10 text-center text-2xl font-bold tracking-tight text-white">
+          Sign in to your account
+        </h2>
+        {err && <div className="mt-3 text-center text-sm text-red-400">{err}</div>}
+      </div>
+
+      <div className="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
+        <form onSubmit={submit} className="space-y-6">
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-gray-100">
+              Email address
+            </label>
+            <div className="mt-2">
+              <input
+                id="email"
+                type="email"
+                name="email"
+                required
+                autoComplete="email"
+                className="block w-full rounded-md bg-white/5 px-3 py-1.5 text-base text-white ring-1 ring-inset ring-white/10 placeholder:text-gray-500 focus:ring-2 focus:ring-indigo-500 sm:text-sm sm:leading-6"
+                value={form.email}
+                onChange={(e) => setForm({ ...form, email: e.target.value })}
+                placeholder="admin@aequitas.com or user@aequitas.com"
+              />
+            </div>
+          </div>
+
+          <div>
+            <div className="flex items-center justify-between">
+              <label htmlFor="password" className="block text-sm font-medium text-gray-100">
+                Password
+              </label>
+              <div className="text-sm">
+                <a href="#" className="font-semibold text-indigo-400 hover:text-indigo-300">
+                  Forgot password?
+                </a>
+              </div>
+            </div>
+            <div className="mt-2">
+              <input
+                id="password"
+                type="password"
+                name="password"
+                required
+                autoComplete="current-password"
+                className="block w-full rounded-md bg-white/5 px-3 py-1.5 text-base text-white ring-1 ring-inset ring-white/10 placeholder:text-gray-500 focus:ring-2 focus:ring-indigo-500 sm:text-sm sm:leading-6"
+                value={form.password}
+                onChange={(e) => setForm({ ...form, password: e.target.value })}
+                placeholder="Secret123!"
+              />
+            </div>
+          </div>
+
+          <div>
+            <button
+              type="submit"
+              className="flex w-full justify-center rounded-md bg-indigo-500 px-3 py-1.5 text-sm font-semibold text-white hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+            >
+              Sign in
+            </button>
+          </div>
+        </form>
+
+        <p className="mt-10 text-center text-sm text-gray-400">
+          Not a member?{' '}
+          <a href="#" className="font-semibold text-indigo-400 hover:text-indigo-300">
+            Start a 14 day free trial
+          </a>
+        </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- style login page using Tailwind UI dark form layout
- give html and body full-height classes
- add notes on Tailwind setup and running login page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb136cc3cc83298936d9275c9ebb97