### PR TITLE
feat(dashboard+auth): fix forgot link; add contacts CSV/manual demo with count; unify button styles

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -10,7 +10,7 @@ export default function Layout({ children }) {
           <Link to="/dashboard" className="font-semibold">Aequitas Reach</Link>
           <div className="flex items-center gap-4">
             <span className="text-sm text-slate-600">{user?.name} • {user?.role}</span>
-            <button onClick={logout} className="text-sm px-3 py-1.5 rounded-xl border">Logout</button>
+            <button onClick={logout} className="btn">Logout</button>
           </div>
         </div>
       </header>

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,14 @@
-/* Tailwind directives inject styles at build time; without this file Tailwind never output any CSS */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+/* Tailwind directives inject styles at build time; without this file Tailwind never output any CSS */
+
+/* Shared app buttons */
+.btn {
+  @apply rounded-md bg-indigo-500 px-3 py-1.5 text-sm font-semibold text-white hover:bg-indigo-400 \
+         focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500\
+         disabled:opacity-60 disabled:cursor-not-allowed;
+}
+.btn-outline {
+  @apply rounded-md border px-3 py-1.5 text-sm font-semibold hover:bg-indigo-50;
+}

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -120,3 +120,43 @@ export async function mockAssignCampaignToUser(campaignId, userId, currentUser){
   return { message:'Assigned to user', campaignId, userId };
 }
 
+// ===== Contacts (demo, in-memory) =====
+let CONTACTS = [
+  // { id: 1, name: 'John Example', phone: '+11234567890' }
+];
+
+export async function mockGetContacts() {
+  await delay(150);
+  return CONTACTS.map(c => ({ ...c }));
+}
+
+export async function mockAddContact({ name, phone }) {
+  await delay(150);
+  const id = CONTACTS.reduce((m, c) => Math.max(m, c.id || 0), 0) + 1;
+  const clean = String(phone || '').trim();
+  CONTACTS.push({ id, name: String(name || '').trim(), phone: clean });
+  return { id };
+}
+
+export async function mockDeleteContact(id) {
+  await delay(120);
+  CONTACTS = CONTACTS.filter(c => c.id !== id);
+  return { ok: true };
+}
+
+export async function mockBulkAddContacts(items) {
+  // items: [{ name, phone }]
+  await delay(200);
+  let added = 0;
+  for (const it of items) {
+    if (!it) continue;
+    const name = String(it.name || '').trim();
+    const phone = String(it.phone || '').trim();
+    if (!phone) continue;
+    const id = CONTACTS.reduce((m, c) => Math.max(m, c.id || 0), 0) + 1;
+    CONTACTS.push({ id, name, phone });
+    added++;
+  }
+  return { added, total: CONTACTS.length };
+}
+

--- a/src/pages/AdminSettings.jsx
+++ b/src/pages/AdminSettings.jsx
@@ -39,7 +39,7 @@ export default function AdminSettings() {
           </label>
         ))}
         <div className="md:col-span-2">
-          <button className="px-4 py-2 rounded-xl bg-black text-white">Save</button>
+          <button className="btn">Save</button>
         </div>
       </form>
     </div>

--- a/src/pages/Campaigns.jsx
+++ b/src/pages/Campaigns.jsx
@@ -89,11 +89,11 @@ export default function Campaigns(){
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-semibold">Campaigns</h1>
         <div className="flex gap-2">
-          <button onClick={()=>setTab('all')}  className={`px-3 py-1.5 rounded-xl border ${tab==='all'?'bg-black text-white':'hover:bg-slate-100'}`}>All</button>
-          <button onClick={()=>setTab('mine')} className={`px-3 py-1.5 rounded-xl border ${tab==='mine'?'bg-black text-white':'hover:bg-slate-100'}`}>Assigned to me</button>
+          <button onClick={()=>setTab('all')} className="btn">All</button>
+          <button onClick={()=>setTab('mine')} className="btn">Assigned to me</button>
           {/* Quick access to lists */}
-          {user?.role==='admin' && <button onClick={()=>nav('/members')} className="px-3 py-1.5 rounded-xl border hover:bg-slate-100">All Members</button>}
-          {(user?.role==='admin' || user?.role==='member') && <button onClick={()=>nav('/users')} className="px-3 py-1.5 rounded-xl border hover:bg-slate-100">All Users</button>}
+          {user?.role==='admin' && <button onClick={()=>nav('/members')} className="btn">All Members</button>}
+          {(user?.role==='admin' || user?.role==='member') && <button onClick={()=>nav('/users')} className="btn">All Users</button>}
         </div>
       </div>
 
@@ -121,9 +121,9 @@ export default function Campaigns(){
                   <td className="px-4 py-2">{c.status}</td>
                   <td className="px-4 py-2">{assignedToMe ? 'Yes' : 'No'}</td>
                   <td className="px-4 py-2 flex flex-wrap gap-2">
-                    <button onClick={()=>execute(c.id)} disabled={!canExecute} className={`px-3 py-1.5 rounded-xl ${canExecute?'bg-indigo-600 text-white hover:bg-indigo-500':'bg-slate-200 text-slate-500 cursor-not-allowed'}`}>Execute</button>
-                    {user?.role==='admin'  && <button onClick={()=>openAssignToMember(c)} className="px-3 py-1.5 rounded-xl border hover:bg-slate-100">Assign Member</button>}
-                    {user?.role==='member' && <button onClick={()=>openAssignToUser(c)}   className="px-3 py-1.5 rounded-xl border hover:bg-slate-100">Assign User</button>}
+                    <button onClick={()=>execute(c.id)} disabled={!canExecute} className="btn">Execute</button>
+                    {user?.role==='admin'  && <button onClick={()=>openAssignToMember(c)} className="btn">Assign Member</button>}
+                    {user?.role==='member' && <button onClick={()=>openAssignToUser(c)} className="btn">Assign User</button>}
                   </td>
                 </tr>
               );

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,13 +1,160 @@
-export default function Dashboard(){
+import { useEffect, useMemo, useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+import { mockGetContacts, mockAddContact, mockDeleteContact, mockBulkAddContacts } from '../lib/api';
+
+export default function Dashboard() {
+  const { user } = useAuth();
+  const [contacts, setContacts] = useState([]);
+  const [form, setForm] = useState({ name: '', phone: '' });
+  const [msg, setMsg] = useState('');
+
+  useEffect(() => { (async () => setContacts(await mockGetContacts()))(); }, []);
+
+  const total = contacts.length;
+
+  // --- CSV parsing: supports header row with "name" and "phone|mobile|number" (case-insensitive)
+  function splitCSV(line) {
+    const re = /("([^"]|"")*"|[^,]+)/g;
+    const out = [];
+    let m;
+    while ((m = re.exec(line)) !== null) out.push(m[0].replace(/^"(.*)"$/, '$1').replace(/""/g, '"').trim());
+    return out;
+  }
+  function parseCSVText(text) {
+    const rows = text.replace(/^\uFEFF/, '').split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+    if (!rows.length) return [];
+    const first = splitCSV(rows[0]);
+    let nameIdx = -1, phoneIdx = -1, start = 0;
+    const headerLooksLikeHeader = first.some(h => /name|phone|mobile|number/i.test(h));
+    if (headerLooksLikeHeader) {
+      first.forEach((h, i) => {
+        if (/name/i.test(h)) nameIdx = i;
+        if (/phone|mobile|number/i.test(h)) phoneIdx = i;
+      });
+      start = 1;
+    } else {
+      // Guess by numeric-looking column
+      const cleaned = first.map(v => v.replace(/[^\d]/g, ''));
+      if (cleaned[0]?.length >= 7) { phoneIdx = 0; nameIdx = 1; }
+      else if (cleaned[1]?.length >= 7) { phoneIdx = 1; nameIdx = 0; }
+      else { nameIdx = 0; phoneIdx = 1; }
+    }
+
+    const items = [];
+    for (let i = start; i < rows.length; i++) {
+      const t = splitCSV(rows[i]);
+      const name = (t[nameIdx] || '').trim();
+      const phone = (t[phoneIdx] || '').trim();
+      if (!phone) continue;
+      items.push({ name, phone });
+    }
+    return items;
+  }
+
+  async function handleCSV(e) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    const items = parseCSVText(text);
+    const res = await mockBulkAddContacts(items);
+    const fresh = await mockGetContacts();
+    setContacts(fresh);
+    setMsg(`Imported ${res.added} contact(s). Total: ${res.total}`);
+    setTimeout(() => setMsg(''), 1500);
+    e.target.value = '';
+  }
+
+  async function addManual(e) {
+    e.preventDefault();
+    if (!form.phone) return;
+    await mockAddContact(form);
+    setForm({ name: '', phone: '' });
+    setContacts(await mockGetContacts());
+  }
+
+  async function del(id) {
+    await mockDeleteContact(id);
+    setContacts(await mockGetContacts());
+  }
+
+  const canManage = user?.role === 'admin'; // only Admin can upload/add/delete in this demo
+  const visible = contacts; // everyone can see the count/list
+
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       <h1 className="text-2xl font-semibold">Dashboard</h1>
+
+      {/* Stats */}
       <div className="grid md:grid-cols-3 gap-4">
-        <div className="p-4 bg-white rounded-2xl border">Total Campaigns: —</div>
+        <div className="p-4 bg-white rounded-2xl border">
+          <div className="text-xs text-slate-500">Total Contacts</div>
+          <div className="text-2xl font-semibold">{total}</div>
+        </div>
         <div className="p-4 bg-white rounded-2xl border">Templates: —</div>
         <div className="p-4 bg-white rounded-2xl border">Delivery Rate: —</div>
       </div>
-      <div className="p-4 bg-white rounded-2xl border"><b>Recent Campaigns</b><div className="text-sm text-slate-500 mt-2">Coming soon…</div></div>
+
+      {/* Contacts management */}
+      <div className="p-4 bg-white rounded-2xl border space-y-4">
+        <div className="flex items-center justify-between">
+          <b>Contacts</b>
+          {msg && <div className="text-sm text-slate-600">{msg}</div>}
+        </div>
+
+        {canManage && (
+          <>
+            <div className="flex flex-col md:flex-row gap-3 items-start md:items-center">
+              <label className="block">
+                <span className="block text-sm mb-1">Upload CSV (Name, Phone)</span>
+                <input type="file" accept=".csv" onChange={handleCSV} className="block text-sm" />
+              </label>
+
+              <form onSubmit={addManual} className="flex gap-2 items-end">
+                <div>
+                  <span className="block text-sm mb-1">Name</span>
+                  <input className="border rounded px-3 py-2 w-48" value={form.name} onChange={e=>setForm({...form, name:e.target.value})} />
+                </div>
+                <div>
+                  <span className="block text-sm mb-1">Phone</span>
+                  <input className="border rounded px-3 py-2 w-48" value={form.phone} onChange={e=>setForm({...form, phone:e.target.value})} required />
+                </div>
+                <button className="btn">Add</button>
+              </form>
+            </div>
+          </>
+        )}
+
+        <div className="bg-white rounded-xl border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50 text-slate-600">
+              <tr>
+                <th className="text-left px-4 py-2">#</th>
+                <th className="text-left px-4 py-2">Name</th>
+                <th className="text-left px-4 py-2">Phone</th>
+                {canManage && <th className="text-left px-4 py-2">Actions</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {visible.map((c, idx) => (
+                <tr key={c.id} className="border-t">
+                  <td className="px-4 py-2">{idx + 1}</td>
+                  <td className="px-4 py-2">{c.name || '—'}</td>
+                  <td className="px-4 py-2">{c.phone}</td>
+                  {canManage && (
+                    <td className="px-4 py-2">
+                      <button onClick={()=>del(c.id)} className="btn">Delete</button>
+                    </td>
+                  )}
+                </tr>
+              ))}
+              {visible.length === 0 && (
+                <tr><td colSpan={canManage ? 4 : 3} className="px-4 py-6 text-center text-slate-500">No contacts</td></tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   );
 }
+

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useAuth } from '../context/AuthContext';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 
 export default function Login() {
   const nav = useNavigate();
@@ -60,9 +60,9 @@ export default function Login() {
                 Password
               </label>
               <div className="text-sm">
-                <a href="#" className="font-semibold text-indigo-400 hover:text-indigo-300">
+                <Link to="/forgot" className="font-semibold text-indigo-400 hover:text-indigo-300">
                   Forgot password?
-                </a>
+                </Link>
               </div>
             </div>
             <div className="mt-2">
@@ -81,10 +81,7 @@ export default function Login() {
           </div>
 
           <div>
-            <button
-              type="submit"
-              className="flex w-full justify-center rounded-md bg-indigo-500 px-3 py-1.5 text-sm font-semibold text-white hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
-            >
+            <button type="submit" className="btn w-full justify-center">
               Sign in
             </button>
           </div>
@@ -93,3 +90,4 @@ export default function Login() {
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- fix login "Forgot password?" link
- add in-memory contacts store with CSV/manual add and delete
- show contacts count on dashboard and unify buttons via shared .btn

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68bbceb9097c832982c9ac957ab69f84