### PR TITLE
feat(campaigns): create campaign + assignee badges + status flow (draft→assigned→sending→done)

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,4 +1,4 @@
-// Mock API for frontend development only.
+// Mock API for frontend-only development.
 // Roles: admin | user | member
 
 const MOCK_ADMIN  = { id: 1, name: 'System Admin',  email: 'admin@aequitas.com',  role: 'admin',  pw: 'Secret123!' };
@@ -7,7 +7,7 @@ const MOCK_MEMBER = { id: 3, name: 'Demo Member',    email: 'member@aequitas.com
 
 let USERS = [MOCK_ADMIN, MOCK_USER, MOCK_MEMBER];
 
-// Minimal admin settings (used elsewhere)
+// Settings (used elsewhere)
 let SETTINGS = {
   'whatsapp.token': '••••••••',
   'whatsapp.phone_number_id': '210058865514527',
@@ -16,15 +16,20 @@ let SETTINGS = {
   'whatsapp.image_url': 'https://example.com/image.jpg',
 };
 
-// Campaigns: assignees array holds IDs (can be user OR member IDs)
+// Contacts demo (if your app has it; harmless if unused)
+let CONTACTS = [];
+
+// Campaigns: assignees = array of USER IDs (can be members or users)
 let CAMPAIGNS = [
-  { id: 101, name: 'Launch Alpha',   status: 'draft',  assignees: [3] },     // assigned to member
+  { id: 101, name: 'Launch Alpha',   status: 'draft',  assignees: [3] },  // member assigned
   { id: 102, name: 'Festive Promo',  status: 'draft',  assignees: [] },
-  { id: 103, name: 'VIP Outreach',   status: 'draft',  assignees: [2,3] },   // assigned to user & member
+  { id: 103, name: 'VIP Outreach',   status: 'draft',  assignees: [2,3] },// user + member
 ];
 
 function delay(ms=250){ return new Promise(r=>setTimeout(r, ms)); }
+function userById(id){ return USERS.find(u => u.id === id) || null; }
 
+//// ---------- AUTH ----------
 export async function mockLogin({ email, password }) {
   await delay();
   const user = USERS.find(u => u.email === email && u.pw === password);
@@ -34,9 +39,7 @@ export async function mockLogin({ email, password }) {
               : 'mock_user_token';
   return { token, user: { id:user.id, name:user.name, email:user.email, role:user.role } };
 }
-
 export function mockLogout(){ return Promise.resolve({ ok:true }); }
-
 export async function mockMe(token){
   await delay(120);
   const map = {
@@ -50,7 +53,7 @@ export async function mockMe(token){
   return { id:u.id, name:u.name, email:u.email, role:u.role };
 }
 
-// Register: creates a new MEMBER
+//// ---------- REGISTER / FORGOT ----------
 export async function mockRegister({ name, email, password }){
   await delay();
   if (USERS.some(u => u.email.toLowerCase()===email.toLowerCase())) {
@@ -60,63 +63,90 @@ export async function mockRegister({ name, email, password }){
   USERS.push({ id, name, email, role:'member', pw: password });
   return { message: 'Registered successfully. Please log in.', role:'member' };
 }
-
-// Forgot password: always succeed (mock)
 export async function mockForgotPassword({ email }){
   await delay();
   return { message: 'If the email exists, a reset link has been sent.' };
 }
 
-// Admin Settings (unchanged)
+//// ---------- SETTINGS ----------
 export async function mockGetAdminSettings(){ await delay(); return { ...SETTINGS }; }
 export async function mockUpdateAdminSettings(p){ SETTINGS = { ...SETTINGS, ...p }; await delay(); return { message:'Settings updated' }; }
 
-// People
-export async function mockGetPeople(role){ 
+//// ---------- PEOPLE ----------
+export async function mockGetPeople(role){
   await delay();
   return USERS.filter(u => u.role === role).map(u => ({ id:u.id, name:u.name, email:u.email, role:u.role }));
 }
-
-export async function mockGetCampaigns(){
+export async function mockGetAllPeople(){
   await delay();
-  return CAMPAIGNS.map(c => ({ ...c, assignees: [...c.assignees] }));
+  return USERS.map(u => ({ id:u.id, name:u.name, email:u.email, role:u.role }));
 }
 
-// Permissions:
-// - Admin can execute any campaign and assign campaigns to MEMBERS.
-// - Member can execute campaigns assigned to them and assign campaigns to USERS.
-// - User can execute campaigns assigned to them.
+//// ---------- CONTACTS (optional demo) ----------
+export async function mockGetContacts(){ await delay(120); return CONTACTS.map(c => ({...c})); }
+export async function mockAddContact({name,phone}){ await delay(120); const id=(CONTACTS.at(-1)?.id||0)+1; CONTACTS.push({id,name,phone}); return {id}; }
+export async function mockDeleteContact(id){ await delay(100); CONTACTS = CONTACTS.filter(c=>c.id!==id); return {ok:true}; }
+export async function mockBulkAddContacts(items){ await delay(180); let added=0; for(const it of items){ if(!it?.phone) continue; const id=(CONTACTS.at(-1)?.id||0)+1; CONTACTS.push({id,name:it.name||'',phone:String(it.phone)}); added++; } return {added,total:CONTACTS.length}; }
+
+//// ---------- CAMPAIGNS ----------
+/**
+ * Return campaigns + assigneeSummaries: [{id, name, role}]
+ */
+export async function mockGetCampaigns(){
+  await delay();
+  return CAMPAIGNS.map(c => ({
+    ...c,
+    assigneeSummaries: c.assignees
+      .map(id => userById(id))
+      .filter(Boolean)
+      .map(u => ({ id:u.id, name:u.name, role:u.role })),
+  }));
+}
+
+export async function mockCreateCampaign({ name, createdBy }){
+  await delay();
+  const id = CAMPAIGNS.reduce((m,c)=>Math.max(m,c.id),100)+1;
+  const c = { id, name: String(name||'Untitled').trim() || 'Untitled', status:'draft', assignees:[] };
+  CAMPAIGNS.unshift(c);
+  return { id: c.id, status: c.status };
+}
+
+// Permissions (unchanged idea):
+// - Admin: execute any + assign to MEMBERS
+// - Member: execute assigned + assign to USERS
+// - User:   execute assigned
 export async function mockExecuteCampaign(campaignId, currentUser){
   await delay();
   const c = CAMPAIGNS.find(x => x.id===campaignId);
   if (!c) throw new Error('Campaign not found');
-  const isAdmin   = currentUser?.role === 'admin';
-  const isMember  = currentUser?.role === 'member' && c.assignees.includes(currentUser.id);
-  const isUser    = currentUser?.role === 'user'   && c.assignees.includes(currentUser.id);
-  if (!(isAdmin || isMember || isUser)) throw new Error('You are not allowed to execute this campaign');
-  c.status = 'queued';
+  const canAdmin  = currentUser?.role === 'admin';
+  const canMember = currentUser?.role === 'member' && c.assignees.includes(currentUser.id);
+  const canUser   = currentUser?.role === 'user'   && c.assignees.includes(currentUser.id);
+  if (!(canAdmin || canMember || canUser)) throw new Error('You are not allowed to execute this campaign');
+
+  // status: sending → done (simulate)
+  c.status = 'sending';
+  setTimeout(()=>{ c.status = 'done'; }, 1000);
   return { message:'Campaign execution started', id:c.id, status:c.status };
 }
 
 export async function mockAssignCampaignToMember(campaignId, memberId, currentUser){
   await delay();
   if (currentUser?.role !== 'admin') throw new Error('Only Admin can assign to a Member');
-  const c = CAMPAIGNS.find(x => x.id===campaignId);
-  if (!c) throw new Error('Campaign not found');
-  const member = USERS.find(u => u.id===memberId && u.role==='member');
-  if (!member) throw new Error('Member not found');
+  const c = CAMPAIGNS.find(x => x.id===campaignId); if (!c) throw new Error('Campaign not found');
+  const member = USERS.find(u => u.id===memberId && u.role==='member'); if (!member) throw new Error('Member not found');
   if (!c.assignees.includes(member.id)) c.assignees.push(member.id);
-  return { message:'Assigned to member', campaignId, memberId };
+  c.status = 'assigned';
+  return { message:'Assigned to member', campaignId, memberId, status:c.status };
 }
 
 export async function mockAssignCampaignToUser(campaignId, userId, currentUser){
   await delay();
   if (currentUser?.role !== 'member') throw new Error('Only Member can assign to a User');
-  const c = CAMPAIGNS.find(x => x.id===campaignId);
-  if (!c) throw new Error('Campaign not found');
-  const user = USERS.find(u => u.id===userId && u.role==='user');
-  if (!user) throw new Error('User not found');
+  const c = CAMPAIGNS.find(x => x.id===campaignId); if (!c) throw new Error('Campaign not found');
+  const user = USERS.find(u => u.id===userId && u.role==='user'); if (!user) throw new Error('User not found');
   if (!c.assignees.includes(user.id)) c.assignees.push(user.id);
-  return { message:'Assigned to user', campaignId, userId };
+  c.status = 'assigned';
+  return { message:'Assigned to user', campaignId, userId, status:c.status };
 }
 


### PR DESCRIPTION
## Summary
- extend campaign API with creation, assignee summaries, and status transitions
- allow Campaigns page to create campaigns, assign members/users, and show assignee badges
- update campaign execution to reflect sending and completion

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68bdae1fcd8483299c71abb4f5ba1556