### PR TITLE
fix(auth+ui): enable /forgot navigation; show campaign & template counts on dashboard (mock)

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -26,6 +26,17 @@ let CAMPAIGNS = [
   { id: 103, name: 'VIP Outreach',   status: 'draft',  assignees: [2,3] },// user + member
 ];
 
+// ----- Templates (mock) -----
+let TEMPLATES = [
+  { id: 1, name: 'Welcome Flow' },
+  { id: 2, name: 'Promo Blast' },
+];
+
+export async function mockGetTemplates() {
+  await delay(120);
+  return TEMPLATES.map(t => ({ ...t }));
+}
+
 function delay(ms=250){ return new Promise(r=>setTimeout(r, ms)); }
 function userById(id){ return USERS.find(u => u.id === id) || null; }
 

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,13 +1,47 @@
+import { useEffect, useState } from 'react';
+import { mockGetCampaigns, mockGetTemplates } from '../lib/api';
+
 export default function Dashboard(){
+  const [counts, setCounts] = useState({ campaigns: '—', templates: '—', delivery: '—' });
+
+  useEffect(()=>{
+    (async ()=>{
+      try{
+        const [cs, ts] = await Promise.all([mockGetCampaigns(), mockGetTemplates()]);
+        setCounts({
+          campaigns: cs.length,
+          templates: ts.length,
+          delivery: '—',
+        });
+      }catch{
+        setCounts({ campaigns:'0', templates:'0', delivery:'—' });
+      }
+    })();
+  },[]);
+
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-semibold">Dashboard</h1>
       <div className="grid md:grid-cols-3 gap-4">
-        <div className="p-4 bg-white rounded-2xl border">Total Campaigns: —</div>
-        <div className="p-4 bg-white rounded-2xl border">Templates: —</div>
-        <div className="p-4 bg-white rounded-2xl border">Delivery Rate: —</div>
+        <div className="p-4 bg-white rounded-2xl border">
+          <div className="text-xs text-slate-500">Total Campaigns</div>
+          <div className="text-2xl font-semibold">{counts.campaigns}</div>
+        </div>
+        <div className="p-4 bg-white rounded-2xl border">
+          <div className="text-xs text-slate-500">Templates</div>
+          <div className="text-2xl font-semibold">{counts.templates}</div>
+        </div>
+        <div className="p-4 bg-white rounded-2xl border">
+          <div className="text-xs text-slate-500">Delivery Rate</div>
+          <div className="text-2xl font-semibold">{counts.delivery}</div>
+        </div>
       </div>
-      <div className="p-4 bg-white rounded-2xl border"><b>Recent Campaigns</b><div className="text-sm text-slate-500 mt-2">Coming soon…</div></div>
+
+      <div className="p-4 bg-white rounded-2xl border">
+        <b>Recent Campaigns</b>
+        <div className="text-sm text-slate-500 mt-2">Coming soon…</div>
+      </div>
     </div>
   );
 }
+

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useAuth } from '../context/AuthContext';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 
 export default function Login() {
   const nav = useNavigate();
@@ -60,9 +60,9 @@ export default function Login() {
                 Password
               </label>
               <div className="text-sm">
-                <a href="#" className="font-semibold text-indigo-400 hover:text-indigo-300">
+                <Link to="/forgot" className="font-semibold text-indigo-400 hover:text-indigo-300">
                   Forgot password?
-                </a>
+                </Link>
               </div>
             </div>
             <div className="mt-2">
@@ -81,10 +81,7 @@ export default function Login() {
           </div>
 
           <div>
-            <button
-              type="submit"
-              className="flex w-full justify-center rounded-md bg-indigo-500 px-3 py-1.5 text-sm font-semibold text-white hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
-            >
+            <button type="submit" className="btn w-full justify-center">
               Sign in
             </button>
           </div>
@@ -93,3 +90,4 @@ export default function Login() {
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- use `Link` for Forgot Password navigation
- mock template list and provide mock template/campaign getters
- display campaign and template counts on dashboard

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68bdb81a7db48329960e8699bcaae95b