### PR TITLE
feat(templates+campaigns): add Templates page, assign templates to campaigns, Campaign Detail view with assign/unassign, and templates count

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,8 @@ import Campaigns from './pages/Campaigns';
 import Members from './pages/Members';
 import Users from './pages/Users';
 import Forbidden from './pages/Forbidden';
+import Templates from './pages/Templates';
+import CampaignDetail from './pages/CampaignDetail';
 
 export default function App(){
   return (
@@ -32,6 +34,8 @@ export default function App(){
           <Route path="/dashboard" element={<ProtectedRoute><Layout><Dashboard/></Layout></ProtectedRoute>} />
           <Route path="/profile"   element={<ProtectedRoute><Layout><Profile/></Layout></ProtectedRoute>} />
           <Route path="/campaigns" element={<ProtectedRoute><Layout><Campaigns/></Layout></ProtectedRoute>} />
+          <Route path="/campaigns/:id" element={<ProtectedRoute><Layout><CampaignDetail/></Layout></ProtectedRoute>} />
+          <Route path="/templates" element={<ProtectedRoute><Layout><Templates/></Layout></ProtectedRoute>} />
           <Route path="/members"   element={<ProtectedRoute><Layout><Members/></Layout></ProtectedRoute>} />
           <Route path="/users"     element={<ProtectedRoute><Layout><Users/></Layout></ProtectedRoute>} />
           <Route path="/admin/settings" element={<ProtectedRoute><Layout><AdminSettings/></Layout></ProtectedRoute>} />

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -29,6 +29,7 @@ export default function Layout({ children }) {
                 <NavLink to="/users" className={({isActive})=>`block px-3 py-2 rounded-xl ${isActive?'bg-black text-white':'hover:bg-slate-100'}`}>Users</NavLink>
               )}
               <NavLink to="/campaigns" className={({isActive})=>`block px-3 py-2 rounded-xl ${isActive?'bg-black text-white':'hover:bg-slate-100'}`}>Campaigns</NavLink>
+              <NavLink to="/templates" className={({isActive})=>`block px-3 py-2 rounded-xl ${isActive?'bg-black text-white':'hover:bg-slate-100'}`}>Templates</NavLink>
               {user?.role === 'admin' && (
                 <NavLink to="/admin/settings" className={({isActive})=>`block px-3 py-2 rounded-xl ${isActive?'bg-black text-white':'hover:bg-slate-100'}`}>Admin Settings</NavLink>
               )}

--- a/src/pages/CampaignDetail.jsx
+++ b/src/pages/CampaignDetail.jsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { mockAssignTemplateToCampaign, mockGetCampaign, mockGetTemplates, mockUnassignTemplateFromCampaign } from '../lib/api';
+
+export default function CampaignDetail(){
+  const { id } = useParams();
+  const [camp, setCamp] = useState(null);
+  const [allTemplates, setAllTemplates] = useState([]);
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const refresh = async ()=>{ setCamp(await mockGetCampaign(id)); setAllTemplates(await mockGetTemplates()); }
+  useEffect(()=>{ refresh(); },[id]);
+
+  const assign = async (tid)=>{ await mockAssignTemplateToCampaign(id, tid); await refresh(); setPickerOpen(false); };
+  const unassign = async (tid)=>{ await mockUnassignTemplateFromCampaign(id, tid); await refresh(); };
+
+  if (!camp) return <div className="p-6 bg-white rounded-2xl border">Loading…</div>;
+
+  const available = allTemplates.filter(t => !(camp.templates || []).some(ct => ct.id === t.id));
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Campaign: {camp.name}</h1>
+        <Link to="/campaigns" className="btn-outline">Back to Campaigns</Link>
+      </div>
+
+      <div className="grid md:grid-cols-3 gap-4">
+        <div className="p-4 bg-white rounded-2xl border">
+          <div className="text-xs text-slate-500">Status</div>
+          <div className="text-2xl font-semibold">{camp.status}</div>
+        </div>
+        <div className="p-4 bg-white rounded-2xl border">
+          <div className="text-xs text-slate-500">Assignees</div>
+          <div className="flex flex-wrap gap-1 mt-1">
+            {(camp.assigneeSummaries || []).map(a=>{
+              const cls = a.role==='member' ? 'bg-indigo-100 text-indigo-700' : a.role==='user' ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-100 text-slate-700';
+              return <span key={a.id} className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs ${cls}`}>{a.name}</span>
+            })}
+            {(!camp.assigneeSummaries || !camp.assigneeSummaries.length) && <span className="text-slate-400">—</span>}
+          </div>
+        </div>
+        <div className="p-4 bg-white rounded-2xl border">
+          <div className="text-xs text-slate-500">Templates</div>
+          <div className="text-2xl font-semibold">{camp.templates?.length || 0}</div>
+        </div>
+      </div>
+
+      <div className="p-4 bg-white rounded-2xl border space-y-3">
+        <div className="flex items-center justify-between">
+          <b>Assigned Templates</b>
+          <button className="btn" onClick={()=>setPickerOpen(true)}>Assign Template</button>
+        </div>
+        <div className="divide-y">
+          {(camp.templates || []).map(t=>(
+            <div key={t.id} className="py-3 flex items-start gap-3">
+              <div className="min-w-[56px] text-slate-500 text-sm">#{t.id}</div>
+              <div className="grow">
+                <div className="font-medium">{t.name}</div>
+                <div className="prose prose-sm max-w-none" dangerouslySetInnerHTML={{ __html: t.html || '' }} />
+              </div>
+              <button className="btn-outline" onClick={()=>unassign(t.id)}>Unassign</button>
+            </div>
+          ))}
+          {(!camp.templates || !camp.templates.length) && <div className="py-6 text-center text-slate-500">No templates assigned</div>}
+        </div>
+      </div>
+
+      {pickerOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-md bg-white rounded-2xl shadow-xl p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <b>Select a template</b>
+              <button className="btn-outline" onClick={()=>setPickerOpen(false)}>Close</button>
+            </div>
+            <div className="max-h-72 overflow-auto divide-y">
+              {available.map(t=>(
+                <button key={t.id} onClick={()=>assign(t.id)} className="w-full text-left px-3 py-2 hover:bg-slate-50">
+                  <div className="font-medium">{t.name}</div>
+                  <div className="text-xs text-slate-500 line-clamp-1" dangerouslySetInnerHTML={{ __html: t.html || '' }} />
+                </button>
+              ))}
+              {!available.length && <div className="px-3 py-6 text-center text-slate-500 text-sm">No more templates</div>}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/pages/Campaigns.jsx
+++ b/src/pages/Campaigns.jsx
@@ -8,7 +8,7 @@ import {
   mockAssignCampaignToUser,
   mockCreateCampaign
 } from '../lib/api';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 // Use fixed classes (no dynamic color strings) so Tailwind includes them.
 function RoleBadge({role, name}){
@@ -141,6 +141,7 @@ export default function Campaigns(){
             <tr>
               <th className="text-left px-4 py-2">ID</th>
               <th className="text-left px-4 py-2">Name</th>
+              <th className="text-left px-4 py-2">Templates</th>
               <th className="text-left px-4 py-2">Assigned To</th>
               <th className="text-left px-4 py-2">Status</th>
               <th className="text-left px-4 py-2">Assigned?</th>
@@ -155,7 +156,8 @@ export default function Campaigns(){
               return (
                 <tr key={c.id} className="border-t">
                   <td className="px-4 py-2">{c.id}</td>
-                  <td className="px-4 py-2">{c.name}</td>
+                  <td className="px-4 py-2"><Link to={`/campaigns/${c.id}`} className="hover:underline">{c.name}</Link></td>
+                  <td className="px-4 py-2">{c.templateCount || 0}</td>
                   <td className="px-4 py-2">
                     <div className="flex flex-wrap gap-1">
                       {(c.assigneeSummaries || []).length > 0

--- a/src/pages/Templates.jsx
+++ b/src/pages/Templates.jsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef, useState } from 'react';
+import { mockCreateTemplate, mockDeleteTemplate, mockGetCampaigns, mockGetTemplates, mockUpdateTemplate } from '../lib/api';
+
+function ToolbarButton({ onClick, children, title }) {
+  return <button type="button" onClick={onClick} title={title} className="btn-outline">{children}</button>;
+}
+
+function Editor({ value, onChange }) {
+  const ref = useRef(null);
+  useEffect(() => { if (ref.current && typeof value === 'string' && ref.current.innerHTML !== value) ref.current.innerHTML = value; }, [value]);
+  const exec = (cmd, arg=null)=>{ document.execCommand(cmd, false, arg); ref.current && onChange(ref.current.innerHTML); };
+  const insertLink = ()=>{ const url = window.prompt('Enter URL (https://...)'); if (url) exec('createLink', url) };
+  const insertImage = ()=>{ const url = window.prompt('Enter image URL (https://...)'); if (url) exec('insertImage', url) };
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-2">
+        <ToolbarButton onClick={()=>exec('bold')}>B</ToolbarButton>
+        <ToolbarButton onClick={()=>exec('italic')}><span className="italic">I</span></ToolbarButton>
+        <ToolbarButton onClick={()=>exec('underline')}><span className="underline">U</span></ToolbarButton>
+        <ToolbarButton onClick={()=>exec('formatBlock','H1')}>H1</ToolbarButton>
+        <ToolbarButton onClick={()=>exec('formatBlock','H2')}>H2</ToolbarButton>
+        <ToolbarButton onClick={()=>exec('insertUnorderedList')}>• List</ToolbarButton>
+        <ToolbarButton onClick={()=>exec('insertOrderedList')}>1. List</ToolbarButton>
+        <ToolbarButton onClick={insertLink}>Link</ToolbarButton>
+        <ToolbarButton onClick={insertImage}>Image</ToolbarButton>
+        <ToolbarButton onClick={()=>exec('removeFormat')}>Clear</ToolbarButton>
+      </div>
+      <div ref={ref} contentEditable className="min-h-[160px] bg-white border rounded-2xl p-3 focus:outline-none"
+           onInput={()=>onChange(ref.current?.innerHTML || '')} suppressContentEditableWarning />
+    </div>
+  );
+}
+
+export default function Templates(){
+  const [list, setList] = useState([]);
+  const [camps, setCamps] = useState([]);
+  const [name, setName] = useState('');
+  const [html, setHtml] = useState('<p>Start typing…</p>');
+  const [assignCid, setAssignCid] = useState('');
+  const [editingId, setEditingId] = useState(null);
+  const [msg, setMsg] = useState('');
+
+  const refresh = async ()=>{ setList(await mockGetTemplates()); setCamps(await mockGetCampaigns()); }
+  useEffect(()=>{ refresh(); },[]);
+
+  const submit = async (e)=>{
+    e.preventDefault();
+    try{
+      if (editingId) {
+        await mockUpdateTemplate(editingId, { name, html });
+        setMsg('Template updated');
+      } else {
+        await mockCreateTemplate({ name, html, campaignId: assignCid || undefined });
+        setMsg('Template created');
+      }
+      setName(''); setHtml('<p>Start typing…</p>'); setAssignCid(''); setEditingId(null);
+      await refresh();
+      setTimeout(()=>setMsg(''), 1200);
+    }catch(err){ setMsg(err.message || 'Failed'); setTimeout(()=>setMsg(''), 1500); }
+  };
+
+  const startEdit = (t)=>{ setEditingId(t.id); setName(t.name); setHtml(t.html || '<p></p>'); window.scrollTo({ top:0, behavior:'smooth' }); };
+  const del = async (id)=>{ await mockDeleteTemplate(id); await refresh(); };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold">Templates</h1>
+      {msg && <div className="text-sm text-slate-700 bg-white border rounded-xl px-3 py-2">{msg}</div>}
+
+      <form onSubmit={submit} className="bg-white border rounded-2xl p-4 space-y-3">
+        <div className="grid md:grid-cols-3 gap-3">
+          <div className="md:col-span-1">
+            <label className="block text-sm mb-1">Template name</label>
+            <input className="border rounded px-3 py-2 w-full" value={name} onChange={(e)=>setName(e.target.value)} placeholder="e.g., Abandoned Cart" required />
+            <label className="block text-sm mb-1 mt-3">Assign to campaign (optional)</label>
+            <select className="border rounded px-3 py-2 w-full" value={assignCid} onChange={(e)=>setAssignCid(e.target.value)}>
+              <option value="">— No assignment —</option>
+              {camps.map(c=> <option key={c.id} value={c.id}>{c.name}</option>)}
+            </select>
+          </div>
+          <div className="md:col-span-2">
+            <label className="block text-sm mb-1">Template content</label>
+            <Editor value={html} onChange={setHtml} />
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <button className="btn">{editingId ? 'Update Template' : 'Create Template'}</button>
+          {editingId && <button type="button" className="btn-outline" onClick={()=>{ setEditingId(null); setName(''); setHtml('<p>Start typing…</p>'); setAssignCid(''); }}>Cancel</button>}
+        </div>
+      </form>
+
+      <div className="bg-white rounded-2xl border overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-50 text-slate-600">
+            <tr>
+              <th className="text-left px-4 py-2">ID</th>
+              <th className="text-left px-4 py-2">Name</th>
+              <th className="text-left px-4 py-2">Assigned To (campaigns)</th>
+              <th className="text-left px-4 py-2">Preview</th>
+              <th className="text-left px-4 py-2">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {list.map(t=>(
+              <tr key={t.id} className="border-t">
+                <td className="px-4 py-2">{t.id}</td>
+                <td className="px-4 py-2">{t.name}</td>
+                <td className="px-4 py-2">{t.campaignIds?.length ? t.campaignIds.join(', ') : '—'}</td>
+                <td className="px-4 py-2"><div className="line-clamp-2 prose prose-sm max-w-none" dangerouslySetInnerHTML={{ __html: t.html || '' }} /></td>
+                <td className="px-4 py-2 flex gap-2">
+                  <button className="btn-outline" onClick={()=>startEdit(t)}>Edit</button>
+                  <button className="btn" onClick={()=>del(t.id)}>Delete</button>
+                </td>
+              </tr>
+            ))}
+            {!list.length && <tr><td colSpan="5" className="px-4 py-6 text-center text-slate-500">No templates yet</td></tr>}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- extend mock API to link templates with campaigns and provide CRUD + assignment helpers
- add Templates page for creating, editing, deleting, and assigning templates
- show campaign detail with template assignments and allow assign/unassign
- show templates count and link campaigns to detail page; add routes and sidebar link

## Testing
- No tests run due to user instruction not to run commands


------
https://chatgpt.com/codex/tasks/task_e_68bdc1eb35348329bb755239666c3c55