### PR TITLE
feat: add templates management

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,8 @@ import Campaigns from './pages/Campaigns';
 import Members from './pages/Members';
 import Users from './pages/Users';
 import Forbidden from './pages/Forbidden';
+import Templates from './pages/Templates';
+import TemplateForm from './pages/TemplateForm';
 
 export default function App(){
   return (
@@ -32,6 +34,9 @@ export default function App(){
           <Route path="/dashboard" element={<ProtectedRoute><Layout><Dashboard/></Layout></ProtectedRoute>} />
           <Route path="/profile"   element={<ProtectedRoute><Layout><Profile/></Layout></ProtectedRoute>} />
           <Route path="/campaigns" element={<ProtectedRoute><Layout><Campaigns/></Layout></ProtectedRoute>} />
+          <Route path="/templates" element={<ProtectedRoute><Layout><Templates/></Layout></ProtectedRoute>} />
+          <Route path="/templates/new" element={<ProtectedRoute><Layout><TemplateForm/></Layout></ProtectedRoute>} />
+          <Route path="/templates/:id" element={<ProtectedRoute><Layout><TemplateForm/></Layout></ProtectedRoute>} />
           <Route path="/members"   element={<ProtectedRoute><Layout><Members/></Layout></ProtectedRoute>} />
           <Route path="/users"     element={<ProtectedRoute><Layout><Users/></Layout></ProtectedRoute>} />
           <Route path="/admin/settings" element={<ProtectedRoute><Layout><AdminSettings/></Layout></ProtectedRoute>} />

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -29,6 +29,7 @@ export default function Layout({ children }) {
                 <NavLink to="/users" className={({isActive})=>`block px-3 py-2 rounded-xl ${isActive?'bg-black text-white':'hover:bg-slate-100'}`}>Users</NavLink>
               )}
               <NavLink to="/campaigns" className={({isActive})=>`block px-3 py-2 rounded-xl ${isActive?'bg-black text-white':'hover:bg-slate-100'}`}>Campaigns</NavLink>
+              <NavLink to="/templates" className={({isActive})=>`block px-3 py-2 rounded-xl ${isActive?'bg-black text-white':'hover:bg-slate-100'}`}>Templates</NavLink>
               {user?.role === 'admin' && (
                 <NavLink to="/admin/settings" className={({isActive})=>`block px-3 py-2 rounded-xl ${isActive?'bg-black text-white':'hover:bg-slate-100'}`}>Admin Settings</NavLink>
               )}

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -74,7 +74,7 @@ export async function mockRegister({ name, email, password }){
   USERS.push({ id, name, email, role:'member', pw: password });
   return { message: 'Registered successfully. Please log in.', role:'member' };
 }
-export async function mockForgotPassword({ email }){
+export async function mockForgotPassword(){
   await delay();
   return { message: 'If the email exists, a reset link has been sent.' };
 }
@@ -114,7 +114,7 @@ export async function mockGetCampaigns(){
   }));
 }
 
-export async function mockCreateCampaign({ name, createdBy }){
+export async function mockCreateCampaign({ name }){
   await delay();
   const id = CAMPAIGNS.reduce((m,c)=>Math.max(m,c.id),100)+1;
   const c = { id, name: String(name||'Untitled').trim() || 'Untitled', status:'draft', assignees:[] };

--- a/src/lib/templates.js
+++ b/src/lib/templates.js
@@ -1,0 +1,52 @@
+const KEY = 'templates';
+const delay = (ms = 100) => new Promise(r => setTimeout(r, ms));
+
+function load(){
+  try {
+    return JSON.parse(localStorage.getItem(KEY)) || [];
+  } catch {
+    return [];
+  }
+}
+
+function save(list){
+  localStorage.setItem(KEY, JSON.stringify(list));
+}
+
+export async function listTemplates(){
+  await delay();
+  return load();
+}
+
+export async function getTemplate(id){
+  await delay();
+  return load().find(t => t.id === Number(id)) || null;
+}
+
+export async function createTemplate({ name, html }){
+  await delay();
+  const list = load();
+  const id = (list.at(-1)?.id || 0) + 1;
+  const t = { id, name, html };
+  list.push(t);
+  save(list);
+  return t;
+}
+
+export async function updateTemplate(id, { name, html }){
+  await delay();
+  const list = load();
+  const idx = list.findIndex(t => t.id === Number(id));
+  if (idx === -1) throw new Error('Template not found');
+  list[idx] = { ...list[idx], name, html };
+  save(list);
+  return list[idx];
+}
+
+export async function deleteTemplate(id){
+  await delay();
+  const list = load().filter(t => t.id !== Number(id));
+  save(list);
+  return { ok: true };
+}
+

--- a/src/pages/TemplateForm.jsx
+++ b/src/pages/TemplateForm.jsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { createTemplate, updateTemplate, getTemplate } from '../lib/templates';
+
+export default function TemplateForm(){
+  const { id } = useParams();
+  const nav = useNavigate();
+  const isEdit = Boolean(id);
+  const [name, setName] = useState('');
+  const [html, setHtml] = useState('');
+
+  useEffect(() => {
+    if (isEdit) {
+      getTemplate(id).then(t => {
+        if (t) {
+          setName(t.name);
+          setHtml(t.html || '');
+        }
+      });
+    }
+  }, [id, isEdit]);
+
+  const save = async e => {
+    e.preventDefault();
+    if (isEdit) {
+      await updateTemplate(id, { name, html });
+    } else {
+      await createTemplate({ name, html });
+    }
+    nav('/templates');
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">{isEdit ? 'Edit Template' : 'Add Template'}</h1>
+        <Link to="/templates" className="btn-outline">Back</Link>
+      </div>
+      <form onSubmit={save} className="bg-white border rounded-2xl p-4 space-y-4">
+        <div>
+          <label className="block text-sm mb-1">Name</label>
+          <input className="border rounded px-3 py-2 w-full" value={name} onChange={e => setName(e.target.value)} required />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">HTML</label>
+          <textarea className="border rounded px-3 py-2 w-full h-48 font-mono" value={html} onChange={e => setHtml(e.target.value)} />
+        </div>
+        <button className="btn">{isEdit ? 'Save' : 'Create'}</button>
+      </form>
+    </div>
+  );
+}
+

--- a/src/pages/Templates.jsx
+++ b/src/pages/Templates.jsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { listTemplates, deleteTemplate } from '../lib/templates';
+
+export default function Templates(){
+  const [list, setList] = useState([]);
+
+  const refresh = async () => setList(await listTemplates());
+  useEffect(() => { refresh(); }, []);
+
+  const remove = async id => {
+    if (!window.confirm('Delete this template?')) return;
+    await deleteTemplate(id);
+    refresh();
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Templates</h1>
+        <Link to="/templates/new" className="btn">Add Template</Link>
+      </div>
+      <div className="bg-white rounded-2xl border overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-50 text-slate-600">
+            <tr>
+              <th className="text-left px-4 py-2">ID</th>
+              <th className="text-left px-4 py-2">Name</th>
+              <th className="text-left px-4 py-2">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {list.map(t => (
+              <tr key={t.id} className="border-t">
+                <td className="px-4 py-2">{t.id}</td>
+                <td className="px-4 py-2">{t.name}</td>
+                <td className="px-4 py-2 flex gap-2">
+                  <Link to={`/templates/${t.id}`} className="btn-outline">Edit</Link>
+                  <button onClick={() => remove(t.id)} className="btn-outline">Delete</button>
+                </td>
+              </tr>
+            ))}
+            {list.length === 0 && (
+              <tr>
+                <td colSpan="3" className="px-4 py-6 text-center text-slate-500">No templates</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add localStorage-backed Templates API with list/create/update/delete helpers
- build Templates pages for listing and editing HTML templates
- expose Templates via navigation and router

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be5ce3d628832980e19332c88e88c5