### PR TITLE
feat: add rich text template descriptions

### DIFF
--- a/src/components/RichTextEditor.jsx
+++ b/src/components/RichTextEditor.jsx
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from 'react';
+
+export default function RichTextEditor({ value, onChange }) {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    if (ref.current && ref.current.innerHTML !== value) {
+      ref.current.innerHTML = value;
+    }
+  }, [value]);
+
+  const exec = (cmd, arg = null) => {
+    document.execCommand(cmd, false, arg);
+    if (ref.current) {
+      ref.current.focus();
+      onChange(ref.current.innerHTML);
+    }
+  };
+
+  const insertLink = () => {
+    const url = window.prompt('Enter URL');
+    if (url) exec('createLink', url);
+  };
+
+  const addImage = () => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'image/*';
+    input.onchange = () => {
+      const file = input.files && input.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = e => {
+        exec('insertImage', e.target.result);
+      };
+      reader.readAsDataURL(file);
+    };
+    input.click();
+  };
+
+  const handleInput = () => {
+    if (ref.current) onChange(ref.current.innerHTML);
+  };
+
+  return (
+    <div className="border rounded w-full">
+      <div className="flex gap-1 border-b p-1">
+        <button type="button" onClick={() => exec('bold')} className="btn-outline px-2">B</button>
+        <button type="button" onClick={() => exec('italic')} className="btn-outline px-2">I</button>
+        <button type="button" onClick={() => exec('underline')} className="btn-outline px-2">U</button>
+        <button type="button" onClick={insertLink} className="btn-outline px-2">Link</button>
+        <button type="button" onClick={addImage} className="btn-outline px-2">Img</button>
+      </div>
+      <div
+        ref={ref}
+        className="px-3 py-2 h-48 overflow-auto focus:outline-none"
+        contentEditable
+        onInput={handleInput}
+      />
+    </div>
+  );
+}
+

--- a/src/lib/templates.js
+++ b/src/lib/templates.js
@@ -1,52 +1,84 @@
 const KEY = 'templates';
 const delay = (ms = 100) => new Promise(r => setTimeout(r, ms));
 
+function save(list){
+  localStorage.setItem(KEY, JSON.stringify(list));
+}
+
 function load(){
   try {
-    return JSON.parse(localStorage.getItem(KEY)) || [];
+    const list = JSON.parse(localStorage.getItem(KEY)) || [];
+    let migrated = false;
+    for (const t of list) {
+      if (t.html && !t.description) {
+        t.description = t.html;
+        delete t.html;
+        migrated = true;
+      }
+    }
+    if (migrated) save(list);
+    return list;
   } catch {
     return [];
   }
 }
 
-function save(list){
-  localStorage.setItem(KEY, JSON.stringify(list));
-}
-
 export async function listTemplates(){
   await delay();
-  return load();
+  try {
+    return { ok: true, data: load() };
+  } catch {
+    return { ok: false, data: [] };
+  }
 }
 
 export async function getTemplate(id){
   await delay();
-  return load().find(t => t.id === Number(id)) || null;
+  try {
+    const t = load().find(t => t.id === Number(id)) || null;
+    if (!t) return { ok: false };
+    return { ok: true, data: t };
+  } catch {
+    return { ok: false };
+  }
 }
 
-export async function createTemplate({ name, html }){
+export async function createTemplate({ name, description }){
   await delay();
-  const list = load();
-  const id = (list.at(-1)?.id || 0) + 1;
-  const t = { id, name, html };
-  list.push(t);
-  save(list);
-  return t;
+  try {
+    const list = load();
+    const id = (list.at(-1)?.id || 0) + 1;
+    const t = { id, name, description };
+    list.push(t);
+    save(list);
+    return { ok: true, data: t };
+  } catch {
+    return { ok: false };
+  }
 }
 
-export async function updateTemplate(id, { name, html }){
+export async function updateTemplate(id, { name, description }){
   await delay();
-  const list = load();
-  const idx = list.findIndex(t => t.id === Number(id));
-  if (idx === -1) throw new Error('Template not found');
-  list[idx] = { ...list[idx], name, html };
-  save(list);
-  return list[idx];
+  try {
+    const list = load();
+    const idx = list.findIndex(t => t.id === Number(id));
+    if (idx === -1) return { ok: false };
+    list[idx] = { ...list[idx], name, description };
+    save(list);
+    return { ok: true, data: list[idx] };
+  } catch {
+    return { ok: false };
+  }
 }
 
 export async function deleteTemplate(id){
   await delay();
-  const list = load().filter(t => t.id !== Number(id));
-  save(list);
-  return { ok: true };
+  try {
+    const list = load().filter(t => t.id !== Number(id));
+    save(list);
+    return { ok: true };
+  } catch {
+    return { ok: false };
+  }
 }
 

--- a/src/pages/TemplateForm.jsx
+++ b/src/pages/TemplateForm.jsx
@@ -1,33 +1,39 @@
 import { useEffect, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { createTemplate, updateTemplate, getTemplate } from '../lib/templates';
+import RichTextEditor from '../components/RichTextEditor';
 
 export default function TemplateForm(){
   const { id } = useParams();
   const nav = useNavigate();
   const isEdit = Boolean(id);
   const [name, setName] = useState('');
-  const [html, setHtml] = useState('');
+  const [description, setDescription] = useState('');
 
   useEffect(() => {
     if (isEdit) {
-      getTemplate(id).then(t => {
-        if (t) {
-          setName(t.name);
-          setHtml(t.html || '');
-        }
-      });
+        getTemplate(id).then(res => {
+          if (res.ok && res.data) {
+            setName(res.data.name);
+            setDescription(res.data.description || '');
+          }
+        });
     }
   }, [id, isEdit]);
 
   const save = async e => {
     e.preventDefault();
-    if (isEdit) {
-      await updateTemplate(id, { name, html });
-    } else {
-      await createTemplate({ name, html });
-    }
-    nav('/templates');
+      let res;
+      if (isEdit) {
+        res = await updateTemplate(id, { name, description });
+      } else {
+        res = await createTemplate({ name, description });
+      }
+      if (res.ok) {
+        nav('/templates');
+      } else {
+        window.alert('Failed to save template');
+      }
   };
 
   return (
@@ -41,10 +47,10 @@ export default function TemplateForm(){
           <label className="block text-sm mb-1">Name</label>
           <input className="border rounded px-3 py-2 w-full" value={name} onChange={e => setName(e.target.value)} required />
         </div>
-        <div>
-          <label className="block text-sm mb-1">HTML</label>
-          <textarea className="border rounded px-3 py-2 w-full h-48 font-mono" value={html} onChange={e => setHtml(e.target.value)} />
-        </div>
+          <div>
+            <label className="block text-sm mb-1">Description</label>
+            <RichTextEditor value={description} onChange={setDescription} />
+          </div>
         <button className="btn">{isEdit ? 'Save' : 'Create'}</button>
       </form>
     </div>

--- a/src/pages/Templates.jsx
+++ b/src/pages/Templates.jsx
@@ -5,13 +5,16 @@ import { listTemplates, deleteTemplate } from '../lib/templates';
 export default function Templates(){
   const [list, setList] = useState([]);
 
-  const refresh = async () => setList(await listTemplates());
+  const refresh = async () => {
+    const res = await listTemplates();
+    if (res.ok) setList(res.data);
+  };
   useEffect(() => { refresh(); }, []);
 
   const remove = async id => {
     if (!window.confirm('Delete this template?')) return;
-    await deleteTemplate(id);
-    refresh();
+    const res = await deleteTemplate(id);
+    if (res.ok) refresh();
   };
 
   return (


### PR DESCRIPTION
## Summary
- replace plain HTML field with rich-text description editor
- migrate stored template `html` fields to `description`
- return `{ok:false}` from template API on errors and handle failures in UI

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be64d70a588329a50042e06716c665