### PR TITLE
Resolve template and campaign name resolution bug

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -178,6 +178,10 @@ export function getTemplateById(id) {
   return (TEMPLATES || []).find(t => Number(t.id) === id) || null;
 }
 
+export function getTemplates() {
+  return TEMPLATES || [];
+}
+
 export function getCampaigns() {
   return CAMPAIGNS || [];
 }
@@ -188,8 +192,17 @@ export function getCampaignById(id) {
 }
 
 export function getCampaignsByTemplateId(templateId) {
-  const id = Number(templateId);
-  return getCampaigns().filter(c => Array.isArray(c.templateIds) && c.templateIds.includes(id));
+  const tid = Number(templateId);
+  return getCampaigns().filter(
+    c => Array.isArray(c.templateIds) && c.templateIds.includes(tid)
+  );
+}
+
+export function getTemplatesByCampaignId(campaignId) {
+  const cid = Number(campaignId);
+  return getTemplates().filter(
+    t => getCampaignById(cid)?.templateIds?.includes(t.id)
+  );
 }
 
 export function assignTemplateToCampaign(templateId, campaignId) {

--- a/src/pages/campaigns/CampaignDetails.jsx
+++ b/src/pages/campaigns/CampaignDetails.jsx
@@ -5,6 +5,7 @@ import {
   mockGetTemplates,
   assignTemplateToCampaign,
   unassignTemplateFromCampaign,
+  getTemplatesByCampaignId,
 } from '../../lib/api';
 
 export default function CampaignDetails() {
@@ -25,11 +26,7 @@ export default function CampaignDetails() {
     refresh();
   }, [refresh]);
 
-  const assignedTemplates = useMemo(() => {
-    if (!campaign) return [];
-    const ids = new Set(campaign.templateIds || []);
-    return templates.filter((t) => ids.has(t.id));
-  }, [campaign, templates]);
+  const assignedTemplates = useMemo(() => getTemplatesByCampaignId(id), [id, campaign, templates]);
 
   const availableTemplates = useMemo(() => {
     const assignedIds = new Set(assignedTemplates.map((t) => t.id));
@@ -122,8 +119,11 @@ export default function CampaignDetails() {
                 <tr key={t.id} className="border-t hover:bg-gray-50">
                   <td className="px-4 py-3">{t.id}</td>
                   <td className="px-4 py-3">
-                    <Link to={`/templates/${t.id}`} className="text-indigo-600 hover:underline">
-                      {t.name}
+                    <Link
+                      to={`/templates/${t.id}`}
+                      className="text-indigo-600 hover:underline"
+                    >
+                      {t.name || 'Untitled Template'}
                     </Link>
                   </td>
                   <td className="px-4 py-3">
@@ -152,7 +152,7 @@ export default function CampaignDetails() {
             <option value="">Select template…</option>
             {availableTemplates.map((t) => (
               <option key={t.id} value={t.id}>
-                {t.name}
+                {t.name || 'Untitled Template'}
               </option>
             ))}
           </select>

--- a/src/pages/templates/TemplateDetails.jsx
+++ b/src/pages/templates/TemplateDetails.jsx
@@ -125,8 +125,11 @@ export default function TemplateDetails() {
                 <tr key={c.id} className="border-t hover:bg-gray-50">
                   <td className="px-4 py-3">{c.id}</td>
                   <td className="px-4 py-3">
-                    <Link to={`/campaigns/${c.id}`} className="text-indigo-600 hover:underline">
-                      {c.name}
+                    <Link
+                      to={`/campaigns/${c.id}`}
+                      className="text-indigo-600 hover:underline"
+                    >
+                      {c.name || 'Unnamed Campaign'}
                     </Link>
                   </td>
                   <td className="px-4 py-3">
@@ -155,7 +158,7 @@ export default function TemplateDetails() {
             <option value="">Select campaign…</option>
             {availableToAssign.map((c) => (
               <option key={c.id} value={c.id}>
-                {c.name}
+                {c.name || 'Unnamed Campaign'}
               </option>
             ))}
           </select>


### PR DESCRIPTION
## Summary
- resolve campaign/template IDs to full objects when querying
- show fallback names for assigned campaigns and templates to avoid undefined
- add API helpers for fetching templates and mapping relationships

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c016ea74e08329b3b300a3936fac2c